### PR TITLE
chore: fix repository url in package manifest to https

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com:MetaMask/nonce-tracker.git"
+    "url": "https://github.com/MetaMask/nonce-tracker.git"
   },
   "license": "ISC",
   "author": "",


### PR DESCRIPTION
https://github.com/MetaMask/nonce-tracker/actions/runs/6279757731/job/17055965437