### PR TITLE
Revert "2.0.0 (#48)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0]
-### Changes
-- **BREAKING:** Switch from `ethjs-query` to `@ethersproject/providers` ([#39](https://github.com/MetaMask/nonce-tracker/pull/39))
-- **BREAKING:** Minimum Node.js version is now 14 ([#42](https://github.com/MetaMask/nonce-tracker/pull/42))
-
 ## [1.2.0]
 ### Changed
 - Add `eth-block-tracker@^4.4.3` ([#12](https://github.com/MetaMask/nonce-tracker/pull/12))
@@ -33,8 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add documentation
 
-[Unreleased]: https://github.com/MetaMask/nonce-tracker/compare/v2.0.0...HEAD
-[2.0.0]: https://github.com/MetaMask/nonce-tracker/compare/v1.2.0...v2.0.0
-[1.2.0]: https://github.com/MetaMask/nonce-tracker/compare/v1.1.0...v1.2.0
-[1.1.0]: https://github.com/MetaMask/nonce-tracker/compare/v1.0.1...v1.1.0
-[1.0.1]: https://github.com/MetaMask/nonce-tracker/releases/tag/v1.0.1
+[Unreleased]: https://github.com/MetaMask/nonce-tracker/compare/v1.2.0...HEAD
+[1.0.0]: https://github.com/MetaMask/nonce-tracker/compare/v1.1.0...v1.2.0
+[1.0.1]: https://github.com/MetaMask/nonce-tracker/compare/v1.0.1...v1.1.0
+[1.0.1]: https://github.com/MetaMask/nonce-tracker/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/MetaMask/nonce-tracker/releases/tag/v1.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nonce-tracker",
-  "version": "2.0.0",
+  "version": "1.2.0",
   "description": "Transaction nonce calculation used in MetaMask.",
   "keywords": [
     "ethereum"


### PR DESCRIPTION
This reverts commit a607bc52340855b4e64048e3e69a132d6c5c3b35 (#48).

Release [failed](https://github.com/MetaMask/nonce-tracker/actions/runs/6387926156/job/17336984444) due to changelog lint. Will be followed up with a fixed publish of the same package.