### PR TITLE
export ancillary types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,10 @@
-import { NonceTracker } from './NonceTracker';
+export { NonceTracker } from './NonceTracker';
 
-export = NonceTracker;
+export type {
+  NonceTrackerOptions,
+  NonceDetails,
+  NonceLock,
+  NetworkNextNonce,
+  HighestContinuousFrom,
+  Transaction,
+} from './NonceTracker';

--- a/test/nonce-tracker-test.js
+++ b/test/nonce-tracker-test.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 // eslint-disable-next-line import/no-unresolved
-const NonceTracker = require('../dist');
+const { NonceTracker } = require('../dist');
 const MockTxGen = require('./lib/mock-tx-gen');
 
 const providerResultStub = {};


### PR DESCRIPTION
- Explicitly export types
- **BREAKING**: Change `NonceTracker` into named export.


```
// Old usage
const NonceTracker = require('nonce-tracker');

// New usage
const { NonceTracker } = require('nonce-tracker');
```