### PR TITLE
fix: eth-block-tracker type-only import

### DIFF
--- a/src/NonceTracker.ts
+++ b/src/NonceTracker.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import { Mutex } from 'async-mutex';
-import { PollingBlockTracker } from 'eth-block-tracker';
+import type { PollingBlockTracker } from 'eth-block-tracker';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
 const { Web3Provider } = require('@ethersproject/providers');


### PR DESCRIPTION
`eth-block-tracker` is imported and unused at runtime, while it is only used for types. This changes it to a type-only import.

---

### Related
- #73

#### Blocking
- #74