### PR TITLE
adapt to eip-1193 provider changes

### DIFF
--- a/test/nonce-tracker-test.js
+++ b/test/nonce-tracker-test.js
@@ -322,12 +322,9 @@ describe('Nonce Tracker', function () {
 });
 
 function generateProviderWith(nonce) {
-  const providerResultStub = {};
-
-  providerResultStub.result = nonce;
   return {
-    sendAsync: (_, cb) => {
-      cb(undefined, providerResultStub);
+    request: () => {
+      return Promise.resolve(nonce);
     },
   };
 }


### PR DESCRIPTION
Replace `sendAsync` with the `request` method to comply with EIP-1193 specification.
 
* Fixes [#68](https://github.com/MetaMask/nonce-tracker/issues/68)